### PR TITLE
issue 152: added smoothOrder = 1 

### DIFF
--- a/Annex60/Utilities/Math/Functions/inverseXRegularized.mo
+++ b/Annex60/Utilities/Math/Functions/inverseXRegularized.mo
@@ -16,7 +16,7 @@ algorithm
     y      := x/delta2 + x*abs(x/delta2/delta*(2 - x2_d2*(3 - x2_d2)));
   end if;
 
-  annotation (
+  annotation (smoothOrder = 1,
     Documentation(info="<html>
 <p>
 Function that approximates <i>y=1 &frasl; x</i>
@@ -28,6 +28,10 @@ See the package <code>Examples</code> for the graph.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+February 5, 2015, by Filip Jorissen:<br/>
+Added <code>smoothOrder = 1</code>.
+</li>
 <li>
 May 10, 2013, by Michael Wetter:<br/>
 Reformulated implementation to avoid unrequired computations.

--- a/Annex60/Utilities/Math/Functions/smoothHeaviside.mo
+++ b/Annex60/Utilities/Math/Functions/smoothHeaviside.mo
@@ -6,13 +6,18 @@ function smoothHeaviside
   output Real y "Result";
 algorithm
  y := Annex60.Utilities.Math.Functions.spliceFunction(1, 0, x, delta);
- annotation (Documentation(info="<html>
+ annotation (smoothOrder = 1,
+ Documentation(info="<html>
 <p>
 Once Lipschitz continuously differentiable approximation to the
 <code>Heaviside(.,.)</code> function.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+February 5, 2015, by Filip Jorissen:<br/>
+Added <code>smoothOrder = 1</code>.
+</li>
 <li>
 July 14, 2010, by Wangda Zuo, Michael Wetter:<br/>
 First implementation.

--- a/Annex60/Utilities/Math/Functions/smoothLimit.mo
+++ b/Annex60/Utilities/Math/Functions/smoothLimit.mo
@@ -13,13 +13,18 @@ algorithm
   cor :=deltaX/10;
   y := Annex60.Utilities.Math.Functions.smoothMax(x,l+deltaX,cor);
   y := Annex60.Utilities.Math.Functions.smoothMin(y,u-deltaX,cor);
-  annotation (Documentation(info="<html>
+  annotation (smoothOrder = 1,
+  Documentation(info="<html>
 <p>
 Once continuously differentiable approximation to the <code>limit(.,.)</code> function.
 The output is bounded to be in <i>[l, u]</i>.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+February 5, 2015, by Filip Jorissen:<br/>
+Added <code>smoothOrder = 1</code>.
+</li>
 <li>
 Sept 1, 2010, by Michael Wetter:<br/>
 Changed scaling to make sure that bounds are never violated.

--- a/Annex60/Utilities/Math/Functions/smoothMax.mo
+++ b/Annex60/Utilities/Math/Functions/smoothMax.mo
@@ -8,7 +8,7 @@ function smoothMax
 algorithm
   y := Annex60.Utilities.Math.Functions.spliceFunction(
          pos=x1, neg=x2, x=x1-x2, deltax=deltaX);
-  annotation (
+  annotation (smoothOrder = 1,
 Documentation(info="<html>
 <p>
 Once continuously differentiable approximation to the <code>max(.,.)</code> function.
@@ -16,6 +16,10 @@ Once continuously differentiable approximation to the <code>max(.,.)</code> func
 </html>",
 revisions="<html>
 <ul>
+<li>
+February 5, 2015, by Filip Jorissen:<br/>
+Added <code>smoothOrder = 1</code>.
+</li>
 <li>
 August 15, 2008, by Michael Wetter:<br/>
 First implementation.

--- a/Annex60/Utilities/Math/Functions/smoothMin.mo
+++ b/Annex60/Utilities/Math/Functions/smoothMin.mo
@@ -9,13 +9,17 @@ algorithm
   y := Annex60.Utilities.Math.Functions.spliceFunction(
        pos=x1, neg=x2, x=x2-x1, deltax=deltaX);
   annotation (
-Documentation(info="<html>
+Documentation(smoothOrder = 1,info="<html>
 <p>
 Once continuously differentiable approximation to the <code>min(.,.)</code> function.
 </p>
 </html>",
 revisions="<html>
 <ul>
+<li>
+February 5, 2015, by Filip Jorissen:<br/>
+Added <code>smoothOrder = 1</code>.
+</li>
 <li>
 August 15, 2008, by Michael Wetter:<br/>
 First implementation.


### PR DESCRIPTION
Added ```smoothOrder = 1``` in inverseXRegularized, smoothHeaviside, smoothLimit, smoothMax, smoothMin

This is for issue #152 