### PR TITLE
Issue185 clean up

### DIFF
--- a/Annex60/Fluid/Actuators/Valves/Examples/TwoWayValvePressureIndependent.mo
+++ b/Annex60/Fluid/Actuators/Valves/Examples/TwoWayValvePressureIndependent.mo
@@ -118,7 +118,5 @@ First implementation.
 </li>
 </ul>
 </html>"),
-    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,
-            100}}), graphics),
-    __Dymola_experimentSetupOutput);
+    Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100,-100},{100,100}})));
 end TwoWayValvePressureIndependent;

--- a/Annex60/Fluid/HeatExchangers/Examples/Heater_T.mo
+++ b/Annex60/Fluid/HeatExchangers/Examples/Heater_T.mo
@@ -60,6 +60,5 @@ First implementation.
         "Simulate and plot"),
     experiment(
       StopTime=172800,
-      Tolerance=1e-05,
-      __Dymola_Algorithm="Radau"));
+      Tolerance=1e-05));
 end Heater_T;

--- a/Annex60/Fluid/HeatExchangers/Examples/Heater_u.mo
+++ b/Annex60/Fluid/HeatExchangers/Examples/Heater_u.mo
@@ -52,6 +52,5 @@ First implementation.
         "Simulate and plot"),
     experiment(
       StopTime=172800,
-      Tolerance=1e-05,
-      __Dymola_Algorithm="Radau"));
+      Tolerance=1e-05));
 end Heater_u;

--- a/Annex60/Fluid/Interfaces/Examples/PrescribedOutletState.mo
+++ b/Annex60/Fluid/Interfaces/Examples/PrescribedOutletState.mo
@@ -1,6 +1,5 @@
 within Annex60.Fluid.Interfaces.Examples;
 model PrescribedOutletState "Test model for prescribed outlet state"
-  import Annex60;
   extends Modelica.Icons.Example;
 
   package Medium = Annex60.Media.Water;

--- a/Annex60/Fluid/MixingVolumes/Examples/package.order
+++ b/Annex60/Fluid/MixingVolumes/Examples/package.order
@@ -5,3 +5,4 @@ MixingVolumeMFactor
 MixingVolumeMassFlow
 MixingVolumeMoistAir
 MixingVolumePrescribedHeatFlowRate
+MixingVolumeSteadyStateMass

--- a/Annex60/Fluid/Movers/BaseClasses/Characteristics/flowParameters.mo
+++ b/Annex60/Fluid/Movers/BaseClasses/Characteristics/flowParameters.mo
@@ -8,11 +8,6 @@ record flowParameters "Record for flow parameters"
      each min=0, each displayUnit="Pa")
     "Fan or pump total pressure at these flow rates";
 
-  // This is needed for OpenModelica.
-  // fixme: Check if this can be put into FlowMachineInterface instead of here.
-  final parameter Integer n = size(V_flow,1)
-    "Number of data points for flow rate in V_flow vs. pressure data";
-
   annotation (Documentation(info="<html>
 <p>
 Data record for performance data that describe volume flow rate versus

--- a/Annex60/Fluid/Movers/BaseClasses/FlowMachineInterface.mo
+++ b/Annex60/Fluid/Movers/BaseClasses/FlowMachineInterface.mo
@@ -97,7 +97,7 @@ protected
      elseif haveVMax or haveDPMax then 2
      else 3
     "Flag, used to pick the right representatio of the fan or pump pressure curve";
-  final parameter Integer nOri = _per_y.pressure.n
+  final parameter Integer nOri = size(_per_y.pressure.V_flow, 1)
     "Number of data points for pressure curve"
     annotation(Evaluate=true);
 

--- a/Annex60/Fluid/Movers/BaseClasses/FlowMachineInterface.mo
+++ b/Annex60/Fluid/Movers/BaseClasses/FlowMachineInterface.mo
@@ -9,7 +9,6 @@ partial model FlowMachineInterface
             power=_per_y.power,
             motorCooledByFluid=_per_y.motorCooledByFluid,
             use_powerCharacteristic=_per_y.use_powerCharacteristic));
-    // fixme    redeclare replaceable Data.SpeedControlled_y per);
 
   import Modelica.Constants;
   import cha = Annex60.Fluid.Movers.BaseClasses.Characteristics;

--- a/Annex60/Fluid/Movers/BaseClasses/FlowMachineInterface.mo
+++ b/Annex60/Fluid/Movers/BaseClasses/FlowMachineInterface.mo
@@ -62,9 +62,7 @@ protected
     "Second order filter to approximate valve opening time, and to improve numerics"
     annotation (Placement(transformation(extent={{20,81},{34,95}})));
 
-  parameter Data.SpeedControlled_y _per_y "Record with performance data"
-    annotation (choicesAllMatching=true,
-      Placement(transformation(extent={{60,-80},{80,-60}})));
+  parameter Data.SpeedControlled_y _per_y "Record with performance data";
 
   parameter Modelica.SIunits.VolumeFlowRate V_flow_max=
     if haveVMax then

--- a/Annex60/Fluid/Movers/BaseClasses/PowerInterface.mo
+++ b/Annex60/Fluid/Movers/BaseClasses/PowerInterface.mo
@@ -35,9 +35,7 @@ partial model PowerInterface
   //Modelica.SIunits.HeatFlowRate QThe_flow "Heat input into the medium";
 protected
   parameter Data.FlowControlled _perPow
-    "Record with performance data for power"
-    annotation (choicesAllMatching=true,
-      Placement(transformation(extent={{60,-80},{80,-60}})));
+    "Record with performance data for power";
 
   parameter Modelica.SIunits.VolumeFlowRate delta_V_flow
     "Factor used for setting heat input into medium to zero at very small flows";

--- a/Annex60/Fluid/Movers/FlowControlled_dp.mo
+++ b/Annex60/Fluid/Movers/FlowControlled_dp.mo
@@ -57,7 +57,7 @@ protected
     annotation (Placement(transformation(extent={{40,78},{60,98}}),
         iconTransformation(extent={{60,50},{80,70}})));
 equation
-  assert(dp_in >= -Modelica.Constants.eps,
+  assert(dp_in >= -1E-3,
     "dp_in cannot be negative. Obtained dp_in = " + String(dp_in));
 
   connect(dp_in, gain.u) annotation (Line(

--- a/Annex60/Fluid/Movers/SpeedControlled_Nrpm.mo
+++ b/Annex60/Fluid/Movers/SpeedControlled_Nrpm.mo
@@ -14,7 +14,7 @@ model SpeedControlled_Nrpm
   replaceable parameter Data.SpeedControlled_Nrpm per
     "Record with performance data"
     annotation (choicesAllMatching=true,
-      Placement(transformation(extent={{20,-80},{40,-60}})));
+      Placement(transformation(extent={{60,-80},{80,-60}})));
 
   Modelica.Blocks.Interfaces.RealInput Nrpm(unit="1/min")
     "Prescribed rotational speed"

--- a/Annex60/Fluid/Movers/SpeedControlled_y.mo
+++ b/Annex60/Fluid/Movers/SpeedControlled_y.mo
@@ -14,7 +14,7 @@ model SpeedControlled_y
   replaceable parameter Data.SpeedControlled_y per
     "Record with performance data"
     annotation (choicesAllMatching=true,
-      Placement(transformation(extent={{20,-80},{40,-60}})));
+      Placement(transformation(extent={{60,-80},{80,-60}})));
 
   Modelica.Blocks.Interfaces.RealInput y(min=0, unit="1")
     "Constant normalized rotational speed"

--- a/Annex60/Utilities/Math/Examples/SmoothMin.mo
+++ b/Annex60/Utilities/Math/Examples/SmoothMin.mo
@@ -1,6 +1,5 @@
 within Annex60.Utilities.Math.Examples;
 model SmoothMin "Test model for smooth minimum"
-  import Annex60;
   extends Modelica.Icons.Example;
   Annex60.Utilities.Math.SmoothMin smoLim[2](deltaX={0.1,0.02}) "Smooth limit"
     annotation (Placement(transformation(extent={{0,-10},{20,10}})));

--- a/Annex60/Utilities/Psychrometrics/Examples/Density_pTX.mo
+++ b/Annex60/Utilities/Psychrometrics/Examples/Density_pTX.mo
@@ -1,6 +1,5 @@
 within Annex60.Utilities.Psychrometrics.Examples;
 model Density_pTX "Model to test the density computation"
-  import Annex60;
   extends Modelica.Icons.Example;
 
  package Medium = Annex60.Media.Air "Medium model"

--- a/Annex60/Utilities/Psychrometrics/Examples/Phi_pTX.mo
+++ b/Annex60/Utilities/Psychrometrics/Examples/Phi_pTX.mo
@@ -1,7 +1,6 @@
 within Annex60.Utilities.Psychrometrics.Examples;
 model Phi_pTX "Model to test the relative humidity computation"
-  import Annex60;
-  extends Modelica.Icons.Example;
+ extends Modelica.Icons.Example;
 
  package Medium = Annex60.Media.Air "Medium model"
            annotation (choicesAllMatching = true);


### PR DESCRIPTION
This will close #185.

See the commit messages for a justification for each change.

The pump models have been tested again with OpenModelica and they still work (except for `Annex60.Fluid.Movers.Examples.SpeedControlled_y_pumpCurves` which also did not work prior to this change).

All unit tests produce the same results.