### PR TITLE
propagated vol.massDynamics in RadiatorEN442_2.mo to massDynamics 

### DIFF
--- a/Annex60/Fluid/HeatExchangers/Radiators/RadiatorEN442_2.mo
+++ b/Annex60/Fluid/HeatExchangers/Radiators/RadiatorEN442_2.mo
@@ -64,7 +64,7 @@ model RadiatorEN442_2 "Dynamic radiator for space heating"
     each V=VWat/nEle,
     each final m_flow_nominal = m_flow_nominal,
     each final energyDynamics=energyDynamics,
-    each final massDynamics=energyDynamics,
+    each final massDynamics=massDynamics,
     each final p_start=p_start,
     each final T_start=T_start,
     each final X_start=X_start,
@@ -351,6 +351,11 @@ with one plate of water carying fluid, and a height of 0.42 meters.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+April 11, 2015, by Filip Jorissen:<br/>
+Propagated <code>vol.massDynamics</code> to  
+top level parameter <code>massDynamics</code> instead of <code>energyDynamics</code>.
+</li>
 <li>
 November 25, 2014, by Carles Ribas Tugores:<br/>
 Interchange position of <code>fraRad</code> parameter and the complementary <code>(1-fraRad)</code>


### PR DESCRIPTION
instead of energyDynamics

this is for #214 

I reran all unit tests in the ```Fluid``` package. Only ```Heater_T``` gave different results, but since this does not use the radiator model I assume this is due to the different compiler.