### PR TITLE
Issue260 state select

### DIFF
--- a/Annex60/Fluid/Interfaces/ConservationEquation.mo
+++ b/Annex60/Fluid/Interfaces/ConservationEquation.mo
@@ -16,13 +16,11 @@ model ConservationEquation "Lumped volume with mass and energy balance"
 
   // Set nominal attributes where literal values can be used.
   Medium.BaseProperties medium(
-    preferredMediumStates= not (energyDynamics == Modelica.Fluid.Types.Dynamics.SteadyState),
+    preferredMediumStates= false,
     p(start=p_start),
     h(start=hStart),
     T(start=T_start),
-    Xi(start=X_start[1:Medium.nXi],
-       each stateSelect=if (not (substanceDynamics == Modelica.Fluid.Types.Dynamics.SteadyState))
-                     then StateSelect.prefer else StateSelect.default),
+    Xi(start=X_start[1:Medium.nXi]),
     X(start=X_start),
     d(start=rho_nominal)) "Medium properties";
 
@@ -272,6 +270,20 @@ Annex60.Fluid.MixingVolumes.MixingVolume</a>.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+June 5, 2015 by Filip Jorissen:<br/>
+Removed <pre>
+Xi(start=X_start[1:Medium.nXi],
+       each stateSelect=if (not (substanceDynamics == Modelica.Fluid.Types.Dynamics.SteadyState))
+       then StateSelect.prefer else StateSelect.default),
+</pre>
+and set
+<code>preferredMediumStates = false</code>
+because the previous declaration led to more equations and 
+translation problems in large models.
+This is for
+<a href=\"https://github.com/iea-annex60/modelica-annex60/issues/260\">#260</a>.
+</li>
 <li>
 May 22, 2015 by Michael Wetter:<br/>
 Removed <pre>


### PR DESCRIPTION
This is for #260 

I ran unit tests, which give minor differences in results and a relatively large change in result for ```vol1.p``` in ```Annex60.Fluid.MixingVolumes.Examples.MixingVolumeMoistAir```. This can be reduced by increasing the solver tolerance.

I did not yet accept the results since you'd probably want to change the differences and because I get small numerical differences in results compared to the existing results, even without any changes to the code.