### PR TITLE
Issue266 pedantic

### DIFF
--- a/Annex60/Experimental/Benchmarks/AirFlow/Components/SimpleZone.mo
+++ b/Annex60/Experimental/Benchmarks/AirFlow/Components/SimpleZone.mo
@@ -4,7 +4,7 @@ model SimpleZone "A room as a thermal zone represented by its air volume"
   replaceable package Medium = Modelica.Media.Interfaces.PartialMedium
     "Medium in the component";
 
-  parameter Modelica.SIunits.Temperature TRoom = 293.15
+  parameter Medium.Temperature TRoom(start=293.15) = 293.15
     "Indoor air temperature of room in K";
   parameter Modelica.SIunits.Height heightRoom = 3 "Height of room in m";
   parameter Modelica.SIunits.Length lengthRoom = 5 "Length of room in m";
@@ -20,7 +20,8 @@ model SimpleZone "A room as a thermal zone represented by its air volume"
     "Flag to force error control on m_flow. Set to true if interested in flow rate";
 
   Modelica.Thermal.HeatTransfer.Components.ThermalConductor conRoom(G=
-        heightRoom*lengthRoom*UValue)
+        heightRoom*lengthRoom*UValue,
+        port_a(T(start=Medium.T_default)))
     "Thermal conductor between fixed T and Volume"
     annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
   Fluid.MixingVolumes.MixingVolume volRoom(
@@ -57,8 +58,8 @@ model SimpleZone "A room as a thermal zone represented by its air volume"
   Modelica.Fluid.Interfaces.FluidPort_a port_a_vent(redeclare package Medium =
         Medium) "Port that connects to the room volume"
     annotation (Placement(transformation(extent={{-110,70},{-90,90}})));
-  Modelica.Thermal.HeatTransfer.Sources.PrescribedTemperature preTemp
-    "Dry bulb air temperature"
+  Modelica.Thermal.HeatTransfer.Sources.PrescribedTemperature preTemp(T(start=Medium.T_default),
+        port(T(start=Medium.T_default))) "Dry bulb air temperature"
     annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
   BoundaryConditions.WeatherData.Bus weaBus
     "Weather data connection for outdoor air temperature"
@@ -128,6 +129,10 @@ in order to be part of a scalable benchmark. </p>
 Annex60.Airflow.Multizone.Validation.ThreeRoomsContam</a> </p>
 </html>", revisions="<html>
 <ul>
+<li>
+September, 2, 2015 by Marcus Fuchs:<br/>
+Add start values to the ports and temperature in the <code>ThermalConductor</code> and the <code>PrescripedTemperature</code> model. This is for <a href=\"https://github.com/iea-annex60/modelica-annex60/issues/266\"> #266</a>, to work with Dymola 2016 in pedantic mode.
+</li>
 <li>
 February 2015 by Marcus Fuchs:<br/>
 First implementation

--- a/Annex60/Experimental/Benchmarks/AirFlow/Components/SimpleZone.mo
+++ b/Annex60/Experimental/Benchmarks/AirFlow/Components/SimpleZone.mo
@@ -131,7 +131,10 @@ Annex60.Airflow.Multizone.Validation.ThreeRoomsContam</a> </p>
 <ul>
 <li>
 September, 2, 2015 by Marcus Fuchs:<br/>
-Add start values to the ports and temperature in the <code>ThermalConductor</code> and the <code>PrescripedTemperature</code> model. This is for <a href=\"https://github.com/iea-annex60/modelica-annex60/issues/266\"> #266</a>, to work with Dymola 2016 in pedantic mode.
+Add start values to the ports and temperature in the <code>ThermalConductor</code> and the 
+<code>PrescripedTemperature</code> model. This is for 
+<a href=\"https://github.com/iea-annex60/modelica-annex60/issues/266\"> #266</a>, to work with 
+Dymola 2016 in pedantic mode.
 </li>
 <li>
 February 2015 by Marcus Fuchs:<br/>

--- a/Annex60/Experimental/Benchmarks/AirFlow/Components/Staircase.mo
+++ b/Annex60/Experimental/Benchmarks/AirFlow/Components/Staircase.mo
@@ -185,7 +185,10 @@ Annex60.Airflow.Multizone.Validation.ThreeRoomsContam</a> </p>
 <ul>
 <li>
 September, 2, 2015 by Marcus Fuchs:<br/>
-Add start values to the ports and temperature in the <code>ThermalConductor</code> and the <code>PrescripedTemperature</code> model. This is for <a href=\"https://github.com/iea-annex60/modelica-annex60/issues/266\"> #266</a>, to work with Dymola 2016 in pedantic mode.
+Add start values to the ports and temperature in the <code>ThermalConductor</code> and the 
+<code>PrescripedTemperature</code> model. This is for 
+<a href=\"https://github.com/iea-annex60/modelica-annex60/issues/266\"> #266</a>, 
+to work with Dymola 2016 in pedantic mode.
 </li>
 <li>
 February 2015 by Marcus Fuchs:<br/>

--- a/Annex60/Experimental/Benchmarks/AirFlow/Components/Staircase.mo
+++ b/Annex60/Experimental/Benchmarks/AirFlow/Components/Staircase.mo
@@ -29,7 +29,8 @@ model Staircase
     mSenFac=60) "Air volume of staircase element"
     annotation (Placement(transformation(extent={{20,-10},{40,10}})));
   Modelica.Thermal.HeatTransfer.Components.ThermalConductor conRoom(G=
-        heightRoom*widthRoom*UValue)
+        heightRoom*widthRoom*UValue,
+        port_a(T(start=Medium.T_default)))
     "Thermal conductor between fixed T and Volume"
     annotation (Placement(transformation(extent={{-10,-10},{10,10}})));
   Modelica.Fluid.Interfaces.FluidPort_a port_a_toHallway(redeclare package
@@ -91,8 +92,8 @@ model Staircase
     annotation (Placement(transformation(extent={{-6,-6},{6,6}},
         rotation=270,
         origin={-60,30})));
-  Modelica.Thermal.HeatTransfer.Sources.PrescribedTemperature preTemp
-    "Dry bulb air temperature"
+  Modelica.Thermal.HeatTransfer.Sources.PrescribedTemperature preTemp(T(start=Medium.T_default),
+        port(T(start=Medium.T_default))) "Dry bulb air temperature"
     annotation (Placement(transformation(extent={{-40,-10},{-20,10}})));
   BoundaryConditions.WeatherData.Bus weaBus "Weather data connection"
                             annotation (Placement(
@@ -182,6 +183,10 @@ Annex60.Airflow.Multizone.Validation.ThreeRoomsContam</a> </p>
 </html>",
    revisions="<html>
 <ul>
+<li>
+September, 2, 2015 by Marcus Fuchs:<br/>
+Add start values to the ports and temperature in the <code>ThermalConductor</code> and the <code>PrescripedTemperature</code> model. This is for <a href=\"https://github.com/iea-annex60/modelica-annex60/issues/266\"> #266</a>, to work with Dymola 2016 in pedantic mode.
+</li>
 <li>
 February 2015 by Marcus Fuchs:<br/>
 First implementation

--- a/Annex60/Experimental/Benchmarks/AirFlow/Components/ZoneHallway.mo
+++ b/Annex60/Experimental/Benchmarks/AirFlow/Components/ZoneHallway.mo
@@ -242,7 +242,10 @@ Annex60.Airflow.Multizone.Validation.ThreeRoomsContam</a> </p>
 <ul>
 <li>
 September, 2, 2015 by Marcus Fuchs:<br/>
-Add start values to the ports and temperature in the <code>ThermalConductor</code> and the <code>PrescripedTemperature</code> model. This is for <a href=\"https://github.com/iea-annex60/modelica-annex60/issues/266\"> #266</a>, to work with Dymola 2016 in pedantic mode.
+Add start values to the ports and temperature in the <code>ThermalConductor</code> and the 
+<code>PrescripedTemperature</code> model. This is for 
+<a href=\"https://github.com/iea-annex60/modelica-annex60/issues/266\"> #266</a>, 
+to work with Dymola 2016 in pedantic mode.
 </li>
 <li>
 February 2015 by Marcus Fuchs:<br/>

--- a/Annex60/Experimental/Benchmarks/AirFlow/Components/ZoneHallway.mo
+++ b/Annex60/Experimental/Benchmarks/AirFlow/Components/ZoneHallway.mo
@@ -27,7 +27,8 @@ model ZoneHallway
     mSenFac=60) "Air volume of hallway element"
     annotation (Placement(transformation(extent={{20,-10},{40,10}})));
   Modelica.Thermal.HeatTransfer.Components.ThermalConductor conRoom(G=
-        heightRoom*lengthRoom*UValue)
+        heightRoom*lengthRoom*UValue,
+        port_a(T(start=Medium.T_default)))
     "Thermal conductor between fixed T and Volume"
     annotation (Placement(transformation(extent={{-20,-10},{0,10}})));
   Airflow.Multizone.MediumColumn col(
@@ -118,8 +119,8 @@ model ZoneHallway
         rotation=270,
         origin={40,-80})));
 
-  Modelica.Thermal.HeatTransfer.Sources.PrescribedTemperature preTemp
-    "Dry bulb air temperature"
+  Modelica.Thermal.HeatTransfer.Sources.PrescribedTemperature preTemp(T(start=Medium.T_default),
+        port(T(start=Medium.T_default))) "Dry bulb air temperature"
     annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
   BoundaryConditions.WeatherData.Bus weaBus
     "Weather data connection for outdoor air temperature"
@@ -239,6 +240,10 @@ in order to be part of a scalable benchmark. </p>
 Annex60.Airflow.Multizone.Validation.ThreeRoomsContam</a> </p>
 </html>", revisions="<html>
 <ul>
+<li>
+September, 2, 2015 by Marcus Fuchs:<br/>
+Add start values to the ports and temperature in the <code>ThermalConductor</code> and the <code>PrescripedTemperature</code> model. This is for <a href=\"https://github.com/iea-annex60/modelica-annex60/issues/266\"> #266</a>, to work with Dymola 2016 in pedantic mode.
+</li>
 <li>
 February 2015 by Marcus Fuchs:<br/>
 First implementation

--- a/Annex60/Fluid/Examples/Performance/Example1v2.mo
+++ b/Annex60/Fluid/Examples/Performance/Example1v2.mo
@@ -9,7 +9,7 @@ model Example1v2 "Example 1 model with mixing volume"
     each allowFlowReversal=allowFlowReversal.k,
     each nPorts=2,
     each tau=tau,
-    energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial)
+    each energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial)
     "Mixing volumes for adding states in enthalpy circuit"
     annotation (Placement(transformation(extent={{80,-8},{60,12}})));
 
@@ -65,6 +65,11 @@ Submitted: 11th Modelica Conference. Paris, France. Sep. 2015.
 </ul>
 </html>", revisions="<html>
 <ul>
+<li>
+August 31, 2015, by Michael Wetter:<br/>
+Added missing <code>each</code> in declaration of the energy balance
+for the volume.
+</li>
 <li>
 July 14, 2015, by Michael Wetter:<br/>
 Revised documentation.

--- a/bin/runUnitTests.py
+++ b/bin/runUnitTests.py
@@ -57,6 +57,7 @@ def _runUnitTests():
     import buildingspy.development.regressiontest as u
     ut = u.Tester()
     ut.batchMode(batch)
+    ut.pedanticModelica(True)
 #    ut.setNumberOfThreads(1)
 #    ut.deleteTemporaryDirectories(False)
 #    ut.useExistingResults(['/tmp/tmp-Buildings-0-fagmeZ'])


### PR DESCRIPTION
These changes are required for the models to translate in the pedantic Modelica mode.

The file `bin/runUnitTests.py` has also been changed to run the unit tests in the pedantic modelica mode. This requires the latest version of BuildingsPy from the master branch at https://github.com/lbl-srg/BuildingsPy
To use older versions of  BuildingsPy, the line
```
ut.pedanticModelica(True)
```
needs to be removed in `bin/runUnitTests.py`.
By default, BuildingsPy does not use pedantic modelica check as I don't expect that AixLib and IDEAS already work for that mode. Buildings does not yet work in pedantic check, but we will fix this.
