### PR TITLE
Reorder `public`

### DIFF
--- a/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/AltitudeAngle.mo
+++ b/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/AltitudeAngle.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.SolarGeometry.BaseClasses;
 block AltitudeAngle "Solar altitude angle"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput zen(quantity="Angle", unit="rad")
     "Zenith angle"
 annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/Declination.mo
+++ b/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/Declination.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.SolarGeometry.BaseClasses;
 block Declination "Declination angle"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput nDay(quantity="Time", unit="s")
     "One-based day number in seconds"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/IncidenceAngle.mo
+++ b/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/IncidenceAngle.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.SolarGeometry.BaseClasses;
 block IncidenceAngle "The solar incidence angle on a tilted surface"
   extends Modelica.Blocks.Icons.Block;
-public
   parameter Modelica.SIunits.Angle lat "Latitude";
   parameter Modelica.SIunits.Angle azi(displayUnit="degree")
     "Surface azimuth. azi=-90 degree if surface outward unit normal points toward east; azi=0 if it points toward south";

--- a/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/SolarAzimuth.mo
+++ b/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/SolarAzimuth.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.SolarGeometry.BaseClasses;
 block SolarAzimuth "Solar azimuth"
   extends Modelica.Blocks.Icons.Block;
-public
   parameter Modelica.SIunits.Angle lat "Latitude";
   Modelica.Blocks.Interfaces.RealInput zen(quantity="Angle", unit="rad")
     "Zenith angle"

--- a/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/SolarHourAngle.mo
+++ b/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/SolarHourAngle.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.SolarGeometry.BaseClasses;
 block SolarHourAngle "Solar hour angle"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput solTim(quantity="Time", unit="s")
     "Solar time"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/ZenithAngle.mo
+++ b/Annex60/BoundaryConditions/SolarGeometry/BaseClasses/ZenithAngle.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.SolarGeometry.BaseClasses;
 block ZenithAngle "Zenith angle"
   extends Modelica.Blocks.Icons.Block;
-public
   parameter Modelica.SIunits.Angle lat "Latitude";
   Modelica.Blocks.Interfaces.RealInput solHouAng(quantity="Angle", unit="rad")
     "Solar hour angle"

--- a/Annex60/BoundaryConditions/SolarGeometry/IncidenceAngle.mo
+++ b/Annex60/BoundaryConditions/SolarGeometry/IncidenceAngle.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.SolarGeometry;
 block IncidenceAngle "Solar incidence angle on a tilted surface"
   extends Modelica.Blocks.Icons.Block;
-public
   parameter Modelica.SIunits.Angle lat "Latitude";
   parameter Modelica.SIunits.Angle azi "Surface azimuth";
   parameter Modelica.SIunits.Angle til "Surface tilt";
@@ -12,6 +11,8 @@ public
     displayUnit="deg") "Incidence angle" annotation (Placement(transformation(
           extent={{100,-10},{120,10}}), iconTransformation(extent={{100,-10},{
             120,10}})));
+  WeatherData.Bus weaBus
+    annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
 protected
   Annex60.BoundaryConditions.SolarGeometry.BaseClasses.Declination decAng
     "Declination angle"
@@ -24,9 +25,6 @@ protected
     final azi=azi,
     final til=til) "Incidence angle"
     annotation (Placement(transformation(extent={{40,-10},{60,10}})));
-public
-  WeatherData.Bus weaBus
-    annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
 equation
   connect(incAng.incAng, y) annotation (Line(
       points={{61,0},{88.25,0},{88.25,1.16573e-015},{95.5,1.16573e-015},{95.5,0},

--- a/Annex60/BoundaryConditions/SolarGeometry/ZenithAngle.mo
+++ b/Annex60/BoundaryConditions/SolarGeometry/ZenithAngle.mo
@@ -1,19 +1,17 @@
 within Annex60.BoundaryConditions.SolarGeometry;
 block ZenithAngle "Zenith angle"
   extends Modelica.Blocks.Icons.Block;
-public
   parameter Modelica.SIunits.Angle lat "Latitude";
   Modelica.Blocks.Interfaces.RealOutput y(
     final quantity="Angle",
     final unit="rad",
     displayUnit="deg") "Zenith angle"
     annotation (Placement(transformation(extent={{100,-10},{120,10}})));
+  WeatherData.Bus weaBus
+    annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
 protected
    Annex60.BoundaryConditions.SolarGeometry.BaseClasses.ZenithAngle zen(final lat=lat)
     annotation (Placement(transformation(extent={{0,-10},{20,10}})));
-public
-  WeatherData.Bus weaBus
-    annotation (Placement(transformation(extent={{-110,-10},{-90,10}})));
 equation
   connect(zen.zen, y) annotation (Line(
       points={{21,6.10623e-16},{88.25,6.10623e-16},{88.25,1.16573e-15},{95.5,

--- a/Annex60/BoundaryConditions/SolarIrradiation/BaseClasses/BrighteningCoefficient.mo
+++ b/Annex60/BoundaryConditions/SolarIrradiation/BaseClasses/BrighteningCoefficient.mo
@@ -2,7 +2,6 @@ within Annex60.BoundaryConditions.SolarIrradiation.BaseClasses;
 block BrighteningCoefficient "Circumsolar and horizon brightening coefficients"
   extends Modelica.Blocks.Icons.Block;
   import H = Annex60.Utilities.Math.Functions.spliceFunction;
-public
   Modelica.Blocks.Interfaces.RealInput zen(
     quantity="Angle",
     unit="rad",

--- a/Annex60/BoundaryConditions/SolarIrradiation/BaseClasses/DiffuseIsotropic.mo
+++ b/Annex60/BoundaryConditions/SolarIrradiation/BaseClasses/DiffuseIsotropic.mo
@@ -2,7 +2,6 @@ within Annex60.BoundaryConditions.SolarIrradiation.BaseClasses;
 block DiffuseIsotropic
   "Diffuse solar irradiation on a tilted surface with an isotropic model"
   extends Modelica.Blocks.Icons.Block;
-public
   parameter Real rho=0.2 "Ground reflectance";
   parameter Modelica.SIunits.Angle til(displayUnit="deg") "Surface tilt angle";
 
@@ -18,14 +17,12 @@ public
       final unit="W/m2")
     "Diffuse solar irradiation on a tilted surfce from the ground"
     annotation (Placement(transformation(extent={{100,-50},{120,-30}})));
-protected
-  Real til_c "Cosine of tilt angle";
-
-public
   Modelica.Blocks.Interfaces.RealOutput HSkyDifTil(final quantity="RadiantEnergyFluenceRate",
       final unit="W/m2")
     "Diffuse solar irradiation on a tilted surfce from the sky"
     annotation (Placement(transformation(extent={{100,30},{120,50}})));
+protected
+  Real til_c "Cosine of tilt angle";
 equation
   til_c = Modelica.Math.cos(til);
   HSkyDifTil = 0.5*HDifHor*(1 + til_c);

--- a/Annex60/BoundaryConditions/SolarIrradiation/BaseClasses/DiffusePerez.mo
+++ b/Annex60/BoundaryConditions/SolarIrradiation/BaseClasses/DiffusePerez.mo
@@ -2,7 +2,6 @@ within Annex60.BoundaryConditions.SolarIrradiation.BaseClasses;
 block DiffusePerez
   "Hemispherical diffuse irradiation on a tilted surface with Perez's anisotropic model"
   extends Modelica.Blocks.Icons.Block;
-public
   parameter Real rho=0.2 "Ground reflectance";
   parameter Modelica.SIunits.Angle til(displayUnit="deg") "Surface tilt angle";
   Modelica.Blocks.Interfaces.RealInput briCof1 "Brightening Coeffcient F1"

--- a/Annex60/BoundaryConditions/SolarIrradiation/BaseClasses/RelativeAirMass.mo
+++ b/Annex60/BoundaryConditions/SolarIrradiation/BaseClasses/RelativeAirMass.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.SolarIrradiation.BaseClasses;
 block RelativeAirMass "Relative air mass"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput zen(
     quantity="Angle",
     unit="rad",

--- a/Annex60/BoundaryConditions/SolarIrradiation/BaseClasses/SkyBrightness.mo
+++ b/Annex60/BoundaryConditions/SolarIrradiation/BaseClasses/SkyBrightness.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.SolarIrradiation.BaseClasses;
 block SkyBrightness "Sky brightness"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput relAirMas "Relative air mass"
     annotation (Placement(transformation(extent={{-140,20},{-100,60}})));
   Modelica.Blocks.Interfaces.RealInput HDifHor(quantity=

--- a/Annex60/BoundaryConditions/SolarIrradiation/DiffuseIsotropic.mo
+++ b/Annex60/BoundaryConditions/SolarIrradiation/DiffuseIsotropic.mo
@@ -3,7 +3,6 @@ block DiffuseIsotropic
   "Diffuse solar irradiation on a tilted surface with an isotropic sky model"
   extends
     Annex60.BoundaryConditions.SolarIrradiation.BaseClasses.PartialSolarIrradiation;
-public
   parameter Real rho=0.2 "Ground reflectance";
   parameter Boolean outSkyCon=false
     "Output contribution of diffuse irradiation from sky";

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckCeilingHeight.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckCeilingHeight.mo
@@ -2,7 +2,6 @@ within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block CheckCeilingHeight
   "Ensures that the ceiling height is above a lower bound"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput ceiHeiIn(final quantity="Height", final unit=
            "m") "Input ceiling height"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckPressure.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckPressure.mo
@@ -2,7 +2,6 @@ within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block CheckPressure
   "Ensures that the interpolated pressure is between prescribed bounds"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput PIn(final quantity="Pressure", final unit=
            "Pa") "Input pressure"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckRadiation.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckRadiation.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block CheckRadiation "Ensure that the radiation is not smaller than 0"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput HIn(final quantity=
         "RadiantEnergyFluenceRate", final unit="W/m2") "Input radiation"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckRelativeHumidity.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckRelativeHumidity.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block CheckRelativeHumidity "Check the validity of relative humidity"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput relHumIn(final unit="1")
     "Input relative humidity"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckSkyCover.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckSkyCover.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block CheckSkyCover "Constrains the sky cover to [0, 1]"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput nIn(min=0, max=1, unit="1")
     "Input sky cover [0, 10]"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckTemperature.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckTemperature.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block CheckTemperature "Check the validity of temperature data"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput TIn(
     final quantity="ThermodynamicTemperature",
     final unit="K",

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckWindDirection.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckWindDirection.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block CheckWindDirection "Constrains the wind direction to [0, 2*pi] degree"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput nIn(
     final quantity="Angle",
     final unit="rad",

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckWindSpeed.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/CheckWindSpeed.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block CheckWindSpeed "Ensures that the wind speed is non-negative"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput winSpeIn(final quantity="Velocity",
       final unit="m/s") "Input wind speed"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/ConvertRadiation.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/ConvertRadiation.mo
@@ -2,7 +2,6 @@ within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block ConvertRadiation
   "Convert the unit of solar radiation received from the TMY3 data file"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput HIn(final unit="W.h/m2")
     "Input radiation"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/ConvertRelativeHumidity.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/ConvertRelativeHumidity.mo
@@ -2,7 +2,6 @@ within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block ConvertRelativeHumidity
   "Convert the relative humidity from percentage to real"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput relHumIn(unit="1")
     "Value of relative humidity in percentage"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/ConvertTime.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/ConvertTime.mo
@@ -2,7 +2,6 @@ within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block ConvertTime
   "Converts the simulation time to calendar time in scale of 1 year (365 days)"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput modTim(final quantity="Time", final unit=
        "s") "Simulation time"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/EquationOfTime.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/EquationOfTime.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block EquationOfTime "Equation of time"
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput nDay(quantity="Time", unit="s")
     "Zero-based day number in seconds (January 1=0, January 2=86400)"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/Examples/CheckCeilingHeight.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/Examples/CheckCeilingHeight.mo
@@ -3,6 +3,12 @@ model CheckCeilingHeight "Test model for ceiling height check"
   extends Modelica.Icons.Example;
   Annex60.Utilities.Time.ModelTime modTim
     annotation (Placement(transformation(extent={{-80,-20},{-60,0}})));
+  Annex60.BoundaryConditions.WeatherData.BaseClasses.CheckCeilingHeight
+    cheCeiHei "Block that constrains the ceiling height"
+     annotation (Placement(transformation(extent={{40,-20},{60,0}})));
+  Annex60.BoundaryConditions.WeatherData.BaseClasses.ConvertTime conTim
+    "Block that converts time"
+    annotation (Placement(transformation(extent={{-40,-20},{-20,0}})));
 protected
   Modelica.Blocks.Tables.CombiTable1Ds datRea(
     tableOnFile=true,
@@ -13,13 +19,6 @@ protected
     smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative)
     "Data reader"
     annotation (Placement(transformation(extent={{0,-20},{20,0}})));
-public
-  Annex60.BoundaryConditions.WeatherData.BaseClasses.CheckCeilingHeight
-    cheCeiHei "Block that constrains the ceiling height"
-     annotation (Placement(transformation(extent={{40,-20},{60,0}})));
-  Annex60.BoundaryConditions.WeatherData.BaseClasses.ConvertTime conTim
-    "Block that converts time"
-    annotation (Placement(transformation(extent={{-40,-20},{-20,0}})));
 equation
   connect(datRea.y[20], cheCeiHei.ceiHeiIn) annotation (Line(
       points={{21,-9.65517},{30,-9.65517},{30,-10},{38,-10}},

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/Examples/CheckPressure.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/Examples/CheckPressure.mo
@@ -8,6 +8,9 @@ model CheckPressure "Test model for pressure check"
   Annex60.Utilities.Time.ModelTime modTim
     "Block that outputs simulation time"
     annotation (Placement(transformation(extent={{-100,0},{-80,20}})));
+  Annex60.BoundaryConditions.WeatherData.BaseClasses.ConvertTime conTim
+    "Block that converts time"
+    annotation (Placement(transformation(extent={{-60,0},{-40,20}})));
 protected
   Modelica.Blocks.Tables.CombiTable1Ds datRea(
     tableOnFile=true,
@@ -18,10 +21,6 @@ protected
     smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative)
     "Data reader"
     annotation (Placement(transformation(extent={{-20,0},{0,20}})));
-public
-  Annex60.BoundaryConditions.WeatherData.BaseClasses.ConvertTime conTim
-    "Block that converts time"
-    annotation (Placement(transformation(extent={{-60,0},{-40,20}})));
 equation
   connect(datRea.y[4], chePre.PIn) annotation (Line(
       points={{1,9.24138},{10,9.24138},{10,10},{18,10}},

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/Examples/CheckSkyCover.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/Examples/CheckSkyCover.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.WeatherData.BaseClasses.Examples;
 model CheckSkyCover "Test model for checking sky cover"
   extends Modelica.Icons.Example;
-public
   Annex60.BoundaryConditions.WeatherData.BaseClasses.CheckSkyCover
     cheTotSkyCov "Check total sky cover"
     annotation (Placement(transformation(extent={{60,20},{80,40}})));

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/Examples/CheckTemperature.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/Examples/CheckTemperature.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.WeatherData.BaseClasses.Examples;
 model CheckTemperature "Test model for CheckTemperature"
   extends Modelica.Icons.Example;
-public
   Annex60.BoundaryConditions.WeatherData.BaseClasses.CheckTemperature
     cheTemDryBul "Check dry bulb temperature "
     annotation (Placement(transformation(extent={{60,20},{80,40}})));
@@ -11,6 +10,15 @@ public
   Annex60.Utilities.Time.ModelTime modTim
     "Block that outputs the model time"
     annotation (Placement(transformation(extent={{-100,0},{-80,20}})));
+  Annex60.BoundaryConditions.WeatherData.BaseClasses.ConvertTime conTim
+    "Block that converts time"
+    annotation (Placement(transformation(extent={{-60,0},{-40,20}})));
+  Modelica.Blocks.Math.UnitConversions.From_degC from_degC
+    "Block that converts temperature"
+    annotation (Placement(transformation(extent={{20,20},{42,40}})));
+  Modelica.Blocks.Math.UnitConversions.From_degC from_degC1
+    "Block that converts temperature"
+    annotation (Placement(transformation(extent={{20,-20},{42,0}})));
 protected
   Modelica.Blocks.Tables.CombiTable1Ds datRea(
     tableOnFile=true,
@@ -21,17 +29,6 @@ protected
     smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative)
     "Data reader"
     annotation (Placement(transformation(extent={{-20,0},{0,20}})));
-
-public
-  Annex60.BoundaryConditions.WeatherData.BaseClasses.ConvertTime conTim
-    "Block that converts time"
-    annotation (Placement(transformation(extent={{-60,0},{-40,20}})));
-  Modelica.Blocks.Math.UnitConversions.From_degC from_degC
-    "Block that converts temperature"
-    annotation (Placement(transformation(extent={{20,20},{42,40}})));
-  Modelica.Blocks.Math.UnitConversions.From_degC from_degC1
-    "Block that converts temperature"
-    annotation (Placement(transformation(extent={{20,-20},{42,0}})));
 equation
   connect(modTim.y, conTim.modTim) annotation (Line(
       points={{-79,10},{-62,10}},

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/Examples/CheckWindDirection.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/Examples/CheckWindDirection.mo
@@ -3,6 +3,15 @@ model CheckWindDirection "Test model for wind direction check"
   extends Modelica.Icons.Example;
   Annex60.Utilities.Time.ModelTime modTim
     annotation (Placement(transformation(extent={{-100,0},{-80,20}})));
+  Annex60.BoundaryConditions.WeatherData.BaseClasses.CheckWindDirection
+    cheWinDir "Block that constrains the wind direction"
+    annotation (Placement(transformation(extent={{60,0},{80,20}})));
+  Annex60.BoundaryConditions.WeatherData.BaseClasses.ConvertTime conTim
+    "Block that converts time"
+    annotation (Placement(transformation(extent={{-60,0},{-40,20}})));
+  Modelica.Blocks.Math.UnitConversions.From_deg from_deg
+    "Block that converts temperature"
+    annotation (Placement(transformation(extent={{20,0},{42,20}})));
 protected
   Modelica.Blocks.Tables.CombiTable1Ds datRea(
     tableOnFile=true,
@@ -13,16 +22,6 @@ protected
     smoothness=Modelica.Blocks.Types.Smoothness.ContinuousDerivative)
     "Data reader"
     annotation (Placement(transformation(extent={{-20,0},{0,20}})));
-public
-  Annex60.BoundaryConditions.WeatherData.BaseClasses.CheckWindDirection
-    cheWinDir "Block that constrains the wind direction"
-    annotation (Placement(transformation(extent={{60,0},{80,20}})));
-  Annex60.BoundaryConditions.WeatherData.BaseClasses.ConvertTime conTim
-    "Block that converts time"
-    annotation (Placement(transformation(extent={{-60,0},{-40,20}})));
-  Modelica.Blocks.Math.UnitConversions.From_deg from_deg
-    "Block that converts temperature"
-    annotation (Placement(transformation(extent={{20,0},{42,20}})));
 equation
   connect(modTim.y, conTim.modTim) annotation (Line(
       points={{-79,10},{-62,10}},

--- a/Annex60/BoundaryConditions/WeatherData/BaseClasses/LocalCivilTime.mo
+++ b/Annex60/BoundaryConditions/WeatherData/BaseClasses/LocalCivilTime.mo
@@ -1,7 +1,6 @@
 within Annex60.BoundaryConditions.WeatherData.BaseClasses;
 block LocalCivilTime "Converts the clock time to local civil time."
   extends Modelica.Blocks.Icons.Block;
-public
   Modelica.Blocks.Interfaces.RealInput cloTim(final quantity="Time", final unit=
        "s") "Clock time"
     annotation (Placement(transformation(extent={{-140,-20},{-100,20}})));

--- a/Annex60/Controls/Continuous/PIDHysteresisTimer.mo
+++ b/Annex60/Controls/Continuous/PIDHysteresisTimer.mo
@@ -79,6 +79,22 @@ model PIDHysteresisTimer
     final yMax=yMax,
     reverseAction=reverseAction) "Controller to track setpoint"
     annotation (Placement(transformation(extent={{-10,-60},{10,-40}})));
+  OffTimer offHys
+    annotation (Placement(transformation(extent={{-20,0},{0,20}})));
+  Modelica.Blocks.Logical.Timer onTimer
+    annotation (Placement(transformation(extent={{-20,70},{0,90}})));
+  Modelica.Blocks.Logical.Timer offTimer
+    annotation (Placement(transformation(extent={{20,30},{40,50}})));
+         Modelica.Blocks.Interfaces.BooleanOutput on
+    "Outputs true if boiler is on"        annotation (Placement(
+        transformation(extent={{100,-90},{120,-70}})));
+  Modelica.Blocks.Math.Feedback feeBac
+    annotation (Placement(transformation(extent={{-90,-10},{-70,10}})));
+  Modelica.Blocks.Logical.Hysteresis hys(
+    pre_y_start=pre_y_start,
+    uLow=eOff,
+    uHigh=eOn) "Hysteresis element to switch controller on and off"
+    annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
 protected
   Modelica.Blocks.Sources.Constant zer(k=0) "Zero signal"
     annotation (Placement(transformation(extent={{20,-80},{40,-60}})));
@@ -89,31 +105,10 @@ protected
     annotation (Placement(transformation(extent={{20,0},{40,20}})));
   Modelica.Blocks.Logical.And and3
     annotation (Placement(transformation(extent={{60,-10},{80,10}})));
-public
-  OffTimer offHys
-    annotation (Placement(transformation(extent={{-20,0},{0,20}})));
-  Modelica.Blocks.Logical.Timer onTimer
-    annotation (Placement(transformation(extent={{-20,70},{0,90}})));
-protected
   Modelica.Blocks.Logical.Not not1
     annotation (Placement(transformation(extent={{-20,30},{0,50}})));
-public
-  Modelica.Blocks.Logical.Timer offTimer
-    annotation (Placement(transformation(extent={{20,30},{40,50}})));
-         Modelica.Blocks.Interfaces.BooleanOutput on
-    "Outputs true if boiler is on"        annotation (Placement(
-        transformation(extent={{100,-90},{120,-70}})));
-protected
   Modelica.Blocks.Logical.Switch switch1
     annotation (Placement(transformation(extent={{-40,-60},{-20,-40}})));
-public
-  Modelica.Blocks.Math.Feedback feeBac
-    annotation (Placement(transformation(extent={{-90,-10},{-70,10}})));
-  Modelica.Blocks.Logical.Hysteresis hys(
-    pre_y_start=pre_y_start,
-    uLow=eOff,
-    uHigh=eOn) "Hysteresis element to switch controller on and off"
-    annotation (Placement(transformation(extent={{-60,-10},{-40,10}})));
 equation
   connect(u_m, con.u_m) annotation (Line(
       points={{-1.11022e-15,-120},{-1.11022e-15,-105.5},{-6.66131e-16,-105.5},{

--- a/Annex60/Utilities/Diagnostics/BaseClasses/PartialInputCheck.mo
+++ b/Annex60/Utilities/Diagnostics/BaseClasses/PartialInputCheck.mo
@@ -5,13 +5,12 @@ block PartialInputCheck "Assert when condition is violated"
     "Start time for activating the assert";
   parameter Real threShold(min=0)=1E-2 "Threshold for equality comparison";
   parameter String message = "Inputs differ by more than threShold";
-protected
-  parameter Modelica.SIunits.Time t0( fixed=false) "Simulation start time";
-public
   Modelica.Blocks.Interfaces.RealInput u1 "Value to check"
        annotation (Placement(transformation(extent={{-140,40},{-100,80}})));
   Modelica.Blocks.Interfaces.RealInput u2 "Value to check"
        annotation (Placement(transformation(extent={{-140,-80},{-100,-40}})));
+protected
+  parameter Modelica.SIunits.Time t0( fixed=false) "Simulation start time";
 initial equation
   t0 = time + startTime;
 

--- a/Annex60/Utilities/Psychrometrics/X_pTphi.mo
+++ b/Annex60/Utilities/Psychrometrics/X_pTphi.mo
@@ -5,8 +5,6 @@ block X_pTphi
     Annex60.Utilities.Psychrometrics.BaseClasses.HumidityRatioVaporPressure;
 
   package Medium = Annex60.Media.Air "Medium model";
-
-public
   Modelica.Blocks.Interfaces.RealInput T(final unit="K",
                                            displayUnit="degC",
                                            min = 0) "Temperature"


### PR DESCRIPTION
To improve readability all  `public` variables are declared before `protected` ones.   
The top `public` command does not change any functionality, so it has been deleted. 