### PR TITLE
Issue552 start values

### DIFF
--- a/Annex60/Airflow/Multizone/BaseClasses/TwoWayFlowElement.mo
+++ b/Annex60/Airflow/Multizone/BaseClasses/TwoWayFlowElement.mo
@@ -27,9 +27,9 @@ partial model TwoWayFlowElement "Flow resistance that uses the power law"
   Modelica.SIunits.Velocity vAB(nominal=0.01) "Average velocity from A to B";
   Modelica.SIunits.Velocity vBA(nominal=0.01) "Average velocity from B to A";
 
-  Modelica.SIunits.Density rho_a1_inflow(start=1.2)
+  Modelica.SIunits.Density rho_a1_inflow
     "Density of air flowing in from port_a1";
-  Modelica.SIunits.Density rho_a2_inflow(start=1.2)
+  Modelica.SIunits.Density rho_a2_inflow
     "Density of air flowing in from port_a2";
 
   Modelica.SIunits.Area A "Face area";
@@ -130,6 +130,14 @@ for doors that can be open or closed as a function of an input signal.
 </html>",
 revisions="<html>
 <ul>
+<li>
+November 3, 2016, by Michael Wetter:<br/>
+Removed start values for inflowing density
+to simplify the parameter window, and because this can usually
+be computed from the state variables.<br/>
+This is for
+<a href=\"https://github.com/iea-annex60/modelica-annex60/issues/552\">#552</a>.
+</li>
 <li>
 February 24, 2015 by Michael Wetter:<br/>
 Changed model to use

--- a/Annex60/Airflow/Multizone/MediumColumn.mo
+++ b/Annex60/Airflow/Multizone/MediumColumn.mo
@@ -29,9 +29,9 @@ model MediumColumn
 
   Modelica.SIunits.VolumeFlowRate V_flow
     "Volume flow rate at inflowing port (positive when flow from port_a to port_b)";
-  Modelica.SIunits.MassFlowRate m_flow(start=0)
+  Modelica.SIunits.MassFlowRate m_flow
     "Mass flow rate from port_a to port_b (m_flow > 0 is design flow direction)";
-  Modelica.SIunits.PressureDifference dp(start=0, displayUnit="Pa")
+  Modelica.SIunits.PressureDifference dp(displayUnit="Pa")
     "Pressure difference between port_a and port_b";
   Modelica.SIunits.Density rho "Density in medium column";
 protected
@@ -41,17 +41,6 @@ protected
       actualStream(port_a.Xi_outflow)) "Medium properties in port_a";
   Medium.MassFraction Xi[Medium.nXi] "Mass fraction used to compute density";
 initial equation
-  /*
-   assert(abs(Medium.density(Medium.setState_pTX(
-    Medium.p_default,
-    Medium.T_default,
-    Medium.X_default)) - Medium.density(Medium.setState_pTX(
-    Medium.p_default,
-    Medium.T_default + 5,
-    Medium.X_default))) > 1E-10,
-    "Error: The density of the medium that is used to compute buoyancy force is independent of temperature."
-    + "\n       You need to select a different medium model.");
-    */
   // The next assert tests for all allowed values of the enumeration.
   // Testing against densitySelection > 0 gives an error in OpenModelica as enumerations start with 1.
   assert(densitySelection == Annex60.Airflow.Multizone.Types.densitySelection.fromTop
@@ -215,6 +204,13 @@ Annex60.Airflow.Multizone.MediumColumnDynamic</a> instead of this model.
 </html>",
 revisions="<html>
 <ul>
+<li>
+November 3, 2016, by Michael Wetter:<br/>
+Removed start values for mass flow rate and pressure difference
+to simplify the parameter window.<br/>
+This is for
+<a href=\"https://github.com/iea-annex60/modelica-annex60/issues/552\">#552</a>.
+</li>
 <li>
 January 22, 2016, by Michael Wetter:<br/>
 Corrected type declaration of pressure difference.

--- a/Annex60/Fluid/BaseClasses/PartialResistance.mo
+++ b/Annex60/Fluid/BaseClasses/PartialResistance.mo
@@ -2,8 +2,7 @@ within Annex60.Fluid.BaseClasses;
 partial model PartialResistance "Partial model for a hydraulic resistance"
     extends Annex60.Fluid.Interfaces.PartialTwoPortInterface(
      show_T=false,
-     dp(start=0,
-        nominal=if dp_nominal_pos > Modelica.Constants.eps
+     dp(nominal=if dp_nominal_pos > Modelica.Constants.eps
           then dp_nominal_pos else 1),
      m_flow(
         nominal=if m_flow_nominal_pos > Modelica.Constants.eps

--- a/Annex60/Fluid/BaseClasses/PartialResistance.mo
+++ b/Annex60/Fluid/BaseClasses/PartialResistance.mo
@@ -86,6 +86,13 @@ this base class.
 </html>", revisions="<html>
 <ul>
 <li>
+November 3, 2016, by Michael Wetter:<br/>
+Removed start value for pressure difference
+to simplify the parameter window.<br/>
+This is for
+<a href=\"https://github.com/iea-annex60/modelica-annex60/issues/552\">#552</a>.
+</li>
+<li>
 January 26, 2016, by Michael Wetter:<br/>
 Avoided assignment of <code>dp(nominal=0)</code> if <code>dp_nominal_pos = 0</code>
 and of <code>m_flow(nominal=0)</code> if <code>m_flow_nominal_pos = 0</code>

--- a/Annex60/Fluid/Interfaces/PartialFourPortInterface.mo
+++ b/Annex60/Fluid/Interfaces/PartialFourPortInterface.mo
@@ -21,12 +21,12 @@ partial model PartialFourPortInterface
 
   Medium1.MassFlowRate m1_flow = port_a1.m_flow
     "Mass flow rate from port_a1 to port_b1 (m1_flow > 0 is design flow direction)";
-  Modelica.SIunits.PressureDifference dp1(displayUnit="Pa")
+  Modelica.SIunits.PressureDifference dp1(displayUnit="Pa") = port_a1.p - port_b1.p
     "Pressure difference between port_a1 and port_b1";
 
   Medium2.MassFlowRate m2_flow = port_a2.m_flow
     "Mass flow rate from port_a2 to port_b2 (m2_flow > 0 is design flow direction)";
-  Modelica.SIunits.PressureDifference dp2(displayUnit="Pa")
+  Modelica.SIunits.PressureDifference dp2(displayUnit="Pa") = port_a2.p - port_b2.p
     "Pressure difference between port_a2 and port_b2";
 
   Medium1.ThermodynamicState sta_a1=
@@ -62,9 +62,7 @@ protected
   Medium2.ThermodynamicState state_b2_inflow=
     Medium2.setState_phX(port_b2.p, inStream(port_b2.h_outflow), inStream(port_b2.Xi_outflow))
     "state for medium inflowing through port_b2";
-equation
-  dp1 = port_a1.p - port_b1.p;
-  dp2 = port_a2.p - port_b2.p;
+
   annotation (
   preferredView="info",
     Documentation(info="<html>
@@ -82,6 +80,12 @@ mass transfer and pressure drop equations.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 3, 2016, by Michael Wetter:<br/>
+Moved computation of pressure drop to variable assignment so that
+the model won't mix graphical with textual modeling if used as a base
+class for a graphically implemented model.
+</li>
 <li>
 November 3, 2016, by Michael Wetter:<br/>
 Removed start values for mass flow rate and pressure difference

--- a/Annex60/Fluid/Interfaces/PartialFourPortInterface.mo
+++ b/Annex60/Fluid/Interfaces/PartialFourPortInterface.mo
@@ -19,14 +19,14 @@ partial model PartialFourPortInterface
     "= true, if actual temperature at port is computed"
     annotation(Dialog(tab="Advanced",group="Diagnostics"));
 
-  Medium1.MassFlowRate m1_flow(start=0) = port_a1.m_flow
+  Medium1.MassFlowRate m1_flow = port_a1.m_flow
     "Mass flow rate from port_a1 to port_b1 (m1_flow > 0 is design flow direction)";
-  Modelica.SIunits.PressureDifference dp1(start=0, displayUnit="Pa")
+  Modelica.SIunits.PressureDifference dp1(displayUnit="Pa")
     "Pressure difference between port_a1 and port_b1";
 
-  Medium2.MassFlowRate m2_flow(start=0) = port_a2.m_flow
+  Medium2.MassFlowRate m2_flow = port_a2.m_flow
     "Mass flow rate from port_a2 to port_b2 (m2_flow > 0 is design flow direction)";
-  Modelica.SIunits.PressureDifference dp2(start=0, displayUnit="Pa")
+  Modelica.SIunits.PressureDifference dp2(displayUnit="Pa")
     "Pressure difference between port_a2 and port_b2";
 
   Medium1.ThermodynamicState sta_a1=
@@ -82,6 +82,13 @@ mass transfer and pressure drop equations.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 3, 2016, by Michael Wetter:<br/>
+Removed start values for mass flow rate and pressure difference
+to simplify the parameter window.<br/>
+This is for
+<a href=\"https://github.com/iea-annex60/modelica-annex60/issues/552\">#552</a>.
+</li>
 <li>
 January 22, 2016, by Michael Wetter:<br/>
 Corrected type declaration of pressure difference.

--- a/Annex60/Fluid/Interfaces/PartialTwoPortInterface.mo
+++ b/Annex60/Fluid/Interfaces/PartialTwoPortInterface.mo
@@ -16,10 +16,10 @@ partial model PartialTwoPortInterface
     "= true, if actual temperature at port is computed"
     annotation(Dialog(tab="Advanced",group="Diagnostics"));
 
-  Modelica.SIunits.MassFlowRate m_flow(start=m_flow_start) = port_a.m_flow
+  Modelica.SIunits.MassFlowRate m_flow(start=_m_flow_start) = port_a.m_flow
     "Mass flow rate from port_a to port_b (m_flow > 0 is design flow direction)";
 
-  Modelica.SIunits.PressureDifference dp(start=dp_start, displayUnit="Pa")
+  Modelica.SIunits.PressureDifference dp(start=_dp_start, displayUnit="Pa") = port_a.p - port_b.p
     "Pressure difference between port_a and port_b";
 
   Medium.ThermodynamicState sta_a=
@@ -35,13 +35,11 @@ partial model PartialTwoPortInterface
           show_T "Medium properties in port_b";
 
 protected
-  final parameter Modelica.SIunits.MassFlowRate m_flow_start = 0
+  final parameter Modelica.SIunits.MassFlowRate _m_flow_start = 0
   "Start value for m_flow, used to avoid a warning if not set in m_flow, and to avoid m_flow.start in parameter window";
-  final parameter Modelica.SIunits.PressureDifference dp_start(displayUnit="Pa") = 0
+  final parameter Modelica.SIunits.PressureDifference _dp_start(displayUnit="Pa") = 0
   "Start value for dp, used to avoid a warning if not set in dp, and to avoid dp.start in parameter window";
 
-equation
-  dp = port_a.p - port_b.p;
   annotation (
     preferredView="info",
     Documentation(info="<html>
@@ -66,6 +64,21 @@ Annex60.Fluid.Interfaces.StaticTwoPortHeatMassExchanger</a>.
 </p>
 </html>", revisions="<html>
 <ul>
+<li>
+November 3, 2016, by Michael Wetter:<br/>
+Renamed protected parameter <code>m_flow_start</code> to avoid
+a name clash with
+<a href=\"modelica://Annex60.Fluid.Movers.FlowControlled_m_flow\">
+Annex60.Fluid.Movers.FlowControlled_m_flow</a>
+which leads to an error as the definition were different,
+and also renamed protected parameter <code>dp_start</code>.
+This is for
+<a href=\"https://github.com/iea-annex60/modelica-annex60/issues/552\">#552</a>
+<br/>
+Moved computation of pressure drop to variable assignment so that
+the model won't mix graphical with textual modeling if used as a base
+class for a graphically implemented model.
+</li>
 <li>
 November 3, 2016, by Michael Wetter:<br/>
 Removed start values for mass flow rate and pressure difference

--- a/Annex60/Fluid/Interfaces/PartialTwoPortInterface.mo
+++ b/Annex60/Fluid/Interfaces/PartialTwoPortInterface.mo
@@ -16,9 +16,10 @@ partial model PartialTwoPortInterface
     "= true, if actual temperature at port is computed"
     annotation(Dialog(tab="Advanced",group="Diagnostics"));
 
-  Modelica.SIunits.MassFlowRate m_flow(start=0) = port_a.m_flow
+  Modelica.SIunits.MassFlowRate m_flow(start=m_flow_start) = port_a.m_flow
     "Mass flow rate from port_a to port_b (m_flow > 0 is design flow direction)";
-  Modelica.SIunits.PressureDifference dp(start=0, displayUnit="Pa")
+
+  Modelica.SIunits.PressureDifference dp(start=dp_start, displayUnit="Pa")
     "Pressure difference between port_a and port_b";
 
   Medium.ThermodynamicState sta_a=
@@ -32,6 +33,13 @@ partial model PartialTwoPortInterface
                           noEvent(actualStream(port_b.h_outflow)),
                           noEvent(actualStream(port_b.Xi_outflow))) if
           show_T "Medium properties in port_b";
+
+protected
+  final parameter Modelica.SIunits.MassFlowRate m_flow_start = 0
+  "Start value for m_flow, used to avoid a warning if not set in m_flow, and to avoid m_flow.start in parameter window";
+  final parameter Modelica.SIunits.PressureDifference dp_start(displayUnit="Pa") = 0
+  "Start value for dp, used to avoid a warning if not set in dp, and to avoid dp.start in parameter window";
+
 equation
   dp = port_a.p - port_b.p;
   annotation (

--- a/Annex60/Fluid/Interfaces/PartialTwoPortInterface.mo
+++ b/Annex60/Fluid/Interfaces/PartialTwoPortInterface.mo
@@ -67,6 +67,13 @@ Annex60.Fluid.Interfaces.StaticTwoPortHeatMassExchanger</a>.
 </html>", revisions="<html>
 <ul>
 <li>
+November 3, 2016, by Michael Wetter:<br/>
+Removed start values for mass flow rate and pressure difference
+to simplify the parameter window.<br/>
+This is for
+<a href=\"https://github.com/iea-annex60/modelica-annex60/issues/552\">#552</a>.
+</li>
+<li>
 January 22, 2016, by Michael Wetter:<br/>
 Corrected type declaration of pressure difference.
 This is

--- a/Annex60/Fluid/Movers/BaseClasses/PartialFlowMachine.mo
+++ b/Annex60/Fluid/Movers/BaseClasses/PartialFlowMachine.mo
@@ -89,7 +89,7 @@ partial model PartialFlowMachine
         iconTransformation(extent={{-10,-78},{10,-58}})));
 
   // Variables
-  Modelica.SIunits.VolumeFlowRate VMachine_flow = eff.V_flow "Volume flow rate";
+  Modelica.SIunits.VolumeFlowRate VMachine_flow(start=_VMachine_flow) = eff.V_flow "Volume flow rate";
   Modelica.SIunits.PressureDifference dpMachine(displayUnit="Pa")=
       -preSou.dp "Pressure difference";
 
@@ -99,6 +99,9 @@ partial model PartialFlowMachine
 
   // Quantity to control
 protected
+  final parameter Modelica.SIunits.VolumeFlowRate _VMachine_flow = 0
+    "Start value for VMachine_flow, used to avoid a warning if not specified";
+
   parameter Types.PrescribedVariable preVar "Type of prescribed variable";
 
   // The parameter speedIsInput is required to conditionally remove the instance gain.
@@ -372,6 +375,7 @@ initial equation
              Setting nominalValuesDefineDefaultPressureCurve=true will suppress this warning.",
          level=AssertionLevel.warning);
 
+
 equation
   connect(prePow.port, vol.heatPort) annotation (Line(
       points={{-34,-94},{-60,-94},{-60,10},{-70,10}},
@@ -527,6 +531,12 @@ and more robust simulation, in particular if the mass flow is equal to zero.
 </html>",
       revisions="<html>
 <ul>
+<li>
+November 3, 2016, by Michael Wetter:<br/>
+Set start value for <code>VMachine_flow</code> to avoid a warning in
+<a href=\"modelica://Annex60.Fluid.Movers.Examples.MoverContinuous\">
+Annex60.Fluid.Movers.Examples.MoverContinuous</a>.
+</li>
 <li>
 July 29, 2016, by Michael Wetter:<br/>
 Made <code>Extractor</code> protected so that it can be removed later


### PR DESCRIPTION
This closes #552.

I also moved the computation of `dp` from the `equation` section to the variable declaration so that the model can be used for graphical modeling without having to mix graphical models with textual equations in the `equation` section, which is something we want to avoid per our style guide.