### PR TITLE
Dymola HTML export is saved to help/ by default,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dymosim.exp
 dymosim.lib
 empty.txt
 failure
+help/
 modelDescription.xml
 request
 stat

--- a/Annex60/Controls/Continuous/LimPID.mo
+++ b/Annex60/Controls/Continuous/LimPID.mo
@@ -315,6 +315,7 @@ to the value of the input signal <code>y_reset_in</code>.
 </p>
 </li>
 </ul>
+</p>
 <p>
 Note that this controller implements an integrator anti-windup. Therefore,
 for most applications, keeping the default setting of

--- a/Annex60/Controls/Continuous/LimPID.mo
+++ b/Annex60/Controls/Continuous/LimPID.mo
@@ -315,7 +315,6 @@ to the value of the input signal <code>y_reset_in</code>.
 </p>
 </li>
 </ul>
-</p>
 <p>
 Note that this controller implements an integrator anti-windup. Therefore,
 for most applications, keeping the default setting of


### PR DESCRIPTION
ignoring this directory