### PR TITLE
Html fixes

### DIFF
--- a/Annex60/Controls/Continuous/LimPID.mo
+++ b/Annex60/Controls/Continuous/LimPID.mo
@@ -271,6 +271,7 @@ This model is similar to
 <a href=\"modelica://Modelica.Blocks.Continuous.LimPID\">Modelica.Blocks.Continuous.LimPID</a>,
 except for the following changes:
 </p>
+
 <ol>
 <li>
 <p>
@@ -281,39 +282,35 @@ It can be configured to have a reverse action.
 otherwise the controller output is decreased. Thus,
 </p>
 <ul>
-<li>for a heating coil with a two-way valve, set <code>reverseAction = false</code>, </li>
-<li>for a cooling coils with a two-way valve, set <code>reverseAction = true</code>. </li>
+  <li>for a heating coil with a two-way valve, set <code>reverseAction = false</code>, </li>
+  <li>for a cooling coils with a two-way valve, set <code>reverseAction = true</code>. </li>
 </ul>
 </li>
+
 <li>
 <p>
 It can be configured to enable an input port that allows resetting the controller
 output. The controller output can be reset as follows:
+</p>
 <ul>
-<li>
-<p>
-If <code>reset = Annex60.Types.Reset.Disabled</code>, which is the default,
-then the controller output is never reset.
-</p>
-</li>
-<li>
-<p>
-If <code>reset = Annex60.Types.Reset.Parameter</code>, then a boolean
-input signal <code>trigger</code> is enabled. Whenever the value of
-this input changes from <code>false</code> to <code>true</code>,
-the controller output is reset by setting <code>y</code>
-to the value of the parameter <code>y_reset</code>.
-</p>
-</li>
-<li>
-<p>
-If <code>reset = Annex60.Types.Reset.Input</code>, then a boolean
-input signal <code>trigger</code> is enabled. Whenever the value of
-this input changes from <code>false</code> to <code>true</code>,
-the controller output is reset by setting <code>y</code>
-to the value of the input signal <code>y_reset_in</code>.
-</p>
-</li>
+  <li>
+  If <code>reset = Annex60.Types.Reset.Disabled</code>, which is the default,
+  then the controller output is never reset.
+  </li>
+  <li>
+  If <code>reset = Annex60.Types.Reset.Parameter</code>, then a boolean
+  input signal <code>trigger</code> is enabled. Whenever the value of
+  this input changes from <code>false</code> to <code>true</code>,
+  the controller output is reset by setting <code>y</code>
+  to the value of the parameter <code>y_reset</code>.
+  </li>
+  <li>
+  If <code>reset = Annex60.Types.Reset.Input</code>, then a boolean
+  input signal <code>trigger</code> is enabled. Whenever the value of
+  this input changes from <code>false</code> to <code>true</code>,
+  the controller output is reset by setting <code>y</code>
+  to the value of the input signal <code>y_reset_in</code>.
+  </li>
 </ul>
 <p>
 Note that this controller implements an integrator anti-windup. Therefore,
@@ -325,12 +322,15 @@ switched on, such as as a light dimmer that may slowly increase the luminance, o
 a variable speed drive of a motor that should continuously increase the speed.
 </p>
 </li>
+
 <li>
 The parameter <code>limitsAtInit</code> has been removed.
 </li>
+
 <li>
 Some parameters assignments in the instances have been made final.
 </li>
+
 </ol>
 </html>",
 revisions="<html>

--- a/Annex60/Fluid/FMI/UsersGuide.mo
+++ b/Annex60/Fluid/FMI/UsersGuide.mo
@@ -126,6 +126,7 @@ The main packages are as follows:
   quantities such as mass flow rate, temperature, optional pressure, etc.
   </p>
 </td>
+</tr>
 </table>
 <p>
 The package

--- a/Annex60/Fluid/HeatExchangers/ActiveBeams/BaseClasses/Convector.mo
+++ b/Annex60/Fluid/HeatExchangers/ActiveBeams/BaseClasses/Convector.mo
@@ -139,6 +139,7 @@ equation
            Documentation(info="<html>
 <p>
 In cooling mode, this model adds heat to the water stream. The heat added is equal to:
+</p>
 <p align=\"center\" style=\"font-style:italic;\">
 Q<sub>Beam</sub> = Q<sub>rated</sub> f<sub><code>&#916;</code>T</sub> f<sub>SA</sub> f<sub>W</sub>
 </p>

--- a/Annex60/Fluid/Interfaces/Examples/FourPortHeatMassExchanger.mo
+++ b/Annex60/Fluid/Interfaces/Examples/FourPortHeatMassExchanger.mo
@@ -63,7 +63,7 @@ equation
     Documentation(info="<html>
 <p>
 This example model demonstrates the used of the
-<a href=modelica://Annex60.Fluid.Interfaces.FourPortHeatMassExchanger>FourPortHeatMassExchanger</a> model.
+<a href=\"modelica://Annex60.Fluid.Interfaces.FourPortHeatMassExchanger\">FourPortHeatMassExchanger</a> model.
 </p>
 </html>", revisions="<html>
 <ul>

--- a/Annex60/Utilities/Math/Examples/IntegratorWithReset.mo
+++ b/Annex60/Utilities/Math/Examples/IntegratorWithReset.mo
@@ -69,6 +69,7 @@ which becomes true at <i>t=0</i>, while <code>intWitRes2</code> is triggered
 by a boolean pulse with is true at <i>t=0</i>.
 Hence, <code>intWitRes1</code> starts with <code>y(0)=y_reset</code> while
 <code>intWitRes2</code> starts with <code>y(0)=y_start</code>.
+</p>
 </html>", revisions="<html>
 <ul>
 <li>

--- a/Annex60/Utilities/Math/IntegratorWithReset.mo
+++ b/Annex60/Utilities/Math/IntegratorWithReset.mo
@@ -85,30 +85,25 @@ of the integrator.
 </p>
 <p>
 The output of the integrator can be reset as follows:
+</p>
 <ul>
 <li>
-<p>
 If <code>reset = Annex60.Types.Reset.Disabled</code>, which is the default,
 then the integrator is never reset.
-</p>
 </li>
 <li>
-<p>
 If <code>reset = Annex60.Types.Reset.Parameter</code>, then a boolean
 input signal <code>trigger</code> is enabled. Whenever the value of
 this input changes from <code>false</code> to <code>true</code>,
 the integrator is reset by setting <code>y</code>
 to the value of the parameter <code>y_reset</code>.
-</p>
 </li>
 <li>
-<p>
 If <code>reset = Annex60.Types.Reset.Input</code>, then a boolean
 input signal <code>trigger</code> is enabled. Whenever the value of
 this input changes from <code>false</code> to <code>true</code>,
 the integrator is reset by setting <code>y</code>
 to the value of the input signal <code>y_reset_in</code>.
-</p>
 </li>
 </ul>
 <p>


### PR DESCRIPTION
This closes some unclosed elements and fixes all HTML errors I was able to find.
I used Dymola 2017 FD01, File → Export → HTML → Printable package documentation 
and then loaded the resulting single HTML file into http://htmlhint.com/
HTML check using BuildingsPy and tidy also reports 0 errors.