### PR TITLE
fix some typos

### DIFF
--- a/Annex60/Fluid/HeatExchangers/ActiveBeams/Data/Trox.mo
+++ b/Annex60/Fluid/HeatExchangers/ActiveBeams/Data/Trox.mo
@@ -1,6 +1,6 @@
 within Annex60.Fluid.HeatExchangers.ActiveBeams.Data;
 package Trox "Performance data for Trox"
-  record DID632A_nozzleH_lenght6ft_cooling =
+  record DID632A_nozzleH_length6ft_cooling =
     Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Generic (
       primaryAir(
         r_V = {0,0.714286, 1,1.2857},
@@ -38,7 +38,7 @@ Performance data for Trox active beam for cooling mode.
 </html>"));
 
 
-  record DID632A_nozzleH_lenght6ft_heating =
+  record DID632A_nozzleH_length6ft_heating =
       Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Generic (
       dT(
         f = {0,0.5,1},

--- a/Annex60/Fluid/HeatExchangers/ActiveBeams/Examples/CoolingAndHeating.mo
+++ b/Annex60/Fluid/HeatExchangers/ActiveBeams/Examples/CoolingAndHeating.mo
@@ -92,9 +92,9 @@ model CoolingAndHeating
     redeclare package MediumWat = MediumW,
     redeclare package MediumAir = MediumA,
     redeclare
-      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_lenght6ft_cooling perCoo,
+      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_length6ft_cooling perCoo,
     redeclare
-      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_lenght6ft_heating perHea,
+      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_length6ft_heating perHea,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyStateInitial)
     "Active Beam"
     annotation (Placement(transformation(extent={{26,48},{54,72}})));

--- a/Annex60/Fluid/HeatExchangers/ActiveBeams/Examples/CoolingOnly.mo
+++ b/Annex60/Fluid/HeatExchangers/ActiveBeams/Examples/CoolingOnly.mo
@@ -69,7 +69,7 @@ model CoolingOnly
     redeclare package MediumWat = MediumW,
     redeclare package MediumAir = MediumA,
     redeclare
-      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_lenght6ft_cooling perCoo,
+      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_length6ft_cooling perCoo,
     energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial) "Active beam"
     annotation (Placement(transformation(extent={{26,48},{54,72}})));
 equation

--- a/Annex60/Fluid/HeatExchangers/ActiveBeams/Examples/HeatingOnly.mo
+++ b/Annex60/Fluid/HeatExchangers/ActiveBeams/Examples/HeatingOnly.mo
@@ -78,9 +78,9 @@ model HeatingOnly
     redeclare package MediumWat = MediumW,
     redeclare package MediumAir = MediumA,
     redeclare
-      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_lenght6ft_cooling perCoo,
+      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_length6ft_cooling perCoo,
     redeclare
-      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_lenght6ft_heating perHea,
+      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_length6ft_heating perHea,
     energyDynamics=Modelica.Fluid.Types.Dynamics.FixedInitial) "Active beam"
     annotation (Placement(transformation(extent={{26,48},{54,72}})));
 equation

--- a/Annex60/Fluid/HeatExchangers/ActiveBeams/UsersGuide.mo
+++ b/Annex60/Fluid/HeatExchangers/ActiveBeams/UsersGuide.mo
@@ -130,7 +130,7 @@ The model can be configured to be steady-state or dynamic.
 If configured as dynamic, then a dynamic conservation equation is applied to the water streams
 for heating and for cooling.
 However, because the capacity of the beam depends on its inlet temperature, and is independent of the
-outlet temperature, the heat transfered
+outlet temperature, the heat transferred
 to the room at the port <code>heaPor.Q_flow</code>, as well as the heat added to or removed from the
 water streams, will instantaneously change.
 The only dynamic responses are the water outlet temperatures, which change with a first

--- a/Annex60/Fluid/HeatExchangers/ActiveBeams/Validation/NumberOfBeams.mo
+++ b/Annex60/Fluid/HeatExchangers/ActiveBeams/Validation/NumberOfBeams.mo
@@ -58,9 +58,9 @@ model NumberOfBeams
     redeclare package MediumWat = MediumW,
     redeclare package MediumAir = MediumA,
     redeclare
-      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_lenght6ft_cooling perCoo,
+      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_length6ft_cooling perCoo,
     redeclare
-      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_lenght6ft_heating perHea,
+      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_length6ft_heating perHea,
     nBeams=1,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState)
     "Active beam"
@@ -102,10 +102,10 @@ model NumberOfBeams
     redeclare package MediumWat = MediumW,
     redeclare package MediumAir = MediumA,
     redeclare
-      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_lenght6ft_cooling
+      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_length6ft_cooling
       perCoo,
     redeclare
-      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_lenght6ft_heating
+      Annex60.Fluid.HeatExchangers.ActiveBeams.Data.Trox.DID632A_nozzleH_length6ft_heating
       perHea,
     nBeams=nBeams,
     energyDynamics=Modelica.Fluid.Types.Dynamics.SteadyState)

--- a/Annex60/Resources/www/modelicaDoc.css
+++ b/Annex60/Resources/www/modelicaDoc.css
@@ -299,7 +299,7 @@ table.navigation {
     margin-top: 2em;
 }
 
-.seperator {
+.separator {
     color: gray;
 }
 

--- a/Annex60/ThermalZones/ReducedOrder/EquivalentAirTemperature/VDI6007WithWindow.mo
+++ b/Annex60/ThermalZones/ReducedOrder/EquivalentAirTemperature/VDI6007WithWindow.mo
@@ -44,7 +44,7 @@ equation
   info="<html>
   <p>This model is a variant of the calculations defined in
   VDI 6007 Part 1. It adds a second equivalent air temperature for windows in
-  case heat transfer through windows and exterior walls is handled seperately in
+  case heat transfer through windows and exterior walls is handled separately in
   the Reduced Order Model. The sum of all weightfactors for windows should be
   one as well as the sum for all wall elements.</p>
   </html>"));

--- a/Annex60/ThermalZones/ReducedOrder/EquivalentAirTemperature/package.mo
+++ b/Annex60/ThermalZones/ReducedOrder/EquivalentAirTemperature/package.mo
@@ -44,7 +44,7 @@ in TMY weather data sets (radiation from the environment is missing), the
 influence of this temperature is not considered in the presented 
 models. It is in any case a minor effect as black-body sky temperature and 
 environmental radiative temperature hardly differ. Furthermore, the Guideline 
-VDI 6007 Part 1 calculates the correction term for each orientation seperately 
+VDI 6007 Part 1 calculates the correction term for each orientation separately 
 with individual radiative and convective coefficients of heat transfer. In the 
 presented models, the user can define only one radiative and one convective 
 coefficient of heat transfer. When using area-weighted coefficients, the impact 

--- a/Annex60/ThermalZones/ReducedOrder/Examples/SimpleRoomFourElements.mo
+++ b/Annex60/ThermalZones/ReducedOrder/Examples/SimpleRoomFourElements.mo
@@ -301,7 +301,7 @@ equation
   Solar radiation on tilted surface is calculated using models of
   Annex60. The thermal zone is a simple room defined in Guideline
   VDI 6007 Part 1 (VDI, 2012). All models, parameters and inputs
-  except sunblinds, seperate handling of heat transfer through
+  except sunblinds, separate handling of heat transfer through
   windows, an extra wall element for ground floor (with additional
   area), an extra wall element for roof (with additional area) and
   solar radiation are similar to the ones defined for the

--- a/Annex60/ThermalZones/ReducedOrder/Examples/SimpleRoomOneElement.mo
+++ b/Annex60/ThermalZones/ReducedOrder/Examples/SimpleRoomOneElement.mo
@@ -239,7 +239,7 @@ equation
   Solar radiation on tilted surface is calculated using models of
   Annex60. The thermal zone is a simple room defined in Guideline
   VDI 6007 Part 1 (VDI, 2012). All models, parameters and inputs
-  except sunblinds, seperate handling of heat transfer through
+  except sunblinds, separate handling of heat transfer through
   windows, no wall element for internal walls and solar radiation
   are similar to the ones defined for the guideline&apos;s test
   room. For solar radiation, the example relies on the standard

--- a/Annex60/ThermalZones/ReducedOrder/Examples/SimpleRoomThreeElements.mo
+++ b/Annex60/ThermalZones/ReducedOrder/Examples/SimpleRoomThreeElements.mo
@@ -269,7 +269,7 @@ equation
   Solar radiation on tilted surface is calculated using models of
   Annex60. The thermal zone is a simple room defined in Guideline
   VDI 6007 Part 1 (VDI, 2012). All models, parameters and inputs
-  except sunblinds, seperate handling of heat transfer through
+  except sunblinds, separate handling of heat transfer through
   windows, an extra wall element for ground floor (with additional
   area) and solar radiation are similar to the ones defined for the
   guideline&apos;s test room. For solar radiation, the example

--- a/Annex60/ThermalZones/ReducedOrder/Examples/SimpleRoomTwoElements.mo
+++ b/Annex60/ThermalZones/ReducedOrder/Examples/SimpleRoomTwoElements.mo
@@ -245,7 +245,7 @@ equation
   Solar radiation on tilted surface is calculated using models of
   Annex60. The thermal zone is a simple room defined in Guideline
   VDI 6007 Part 1 (VDI, 2012). All models, parameters and inputs
-  except sunblinds, seperate handling of heat transfer through
+  except sunblinds, separate handling of heat transfer through
   windows and solar radiation are similar to the ones defined for
   the guideline&apos;s test room. For solar radiation, the example
   relies on the standard weather file in Annex60.</p>

--- a/Annex60/ThermalZones/ReducedOrder/RC/BaseClasses/splitFacVal.mo
+++ b/Annex60/ThermalZones/ReducedOrder/RC/BaseClasses/splitFacVal.mo
@@ -43,7 +43,7 @@ algorithm
   unless the area is zero. It substracts the wall area <code>AExt</code>
   for first entry in <code>AArray</code> and <code>AWin</code> for
   second entry in AArray unless <code>AArray[1]</code> and/or
-  <code>AArray[2]</code> are not zero. This is done seperately for each
+  <code>AArray[2]</code> are not zero. This is done separately for each
   orientation. Consequently, the function gives an <code>nRow x nCol</code>
   array back as output. Each row stands for one area in
   <code>AArray</code> and each row for one orientation in
@@ -62,7 +62,7 @@ algorithm
   zeros with length 1.
   For solar radiation through windows, the window and wall area with the same
   orientation as the incoming radiation should be substracted as these areas
-  cannot be hit by the radiation. This needs to be done seperately for each
+  cannot be hit by the radiation. This needs to be done separately for each
   orientation and for exterior walls and windows only, according to:
   <p align=\"center\" style=\"font-style:italic;\">
  SplitFac<sub>i,k</sub> = (AArray[i]

--- a/Annex60/ThermalZones/ReducedOrder/RC/OneElement.mo
+++ b/Annex60/ThermalZones/ReducedOrder/RC/OneElement.mo
@@ -147,14 +147,14 @@ model OneElement "Thermal Zone with one element for exterior walls"
     final splitFactor=splitFactor,
     final nOut=dimension,
     final nIn=1) if ATot > 0
-    "Splits incoming internal gains into seperate gains for each wall element, 
+    "Splits incoming internal gains into separate gains for each wall element, 
     weighted by their area"
     annotation (Placement(transformation(extent={{210,76},{190,96}})));
   BaseClasses.ThermSplitter thermSplitterSolRad(
     final splitFactor=splitFactorSolRad,
     final nOut=dimension,
     final nIn=nOrientations) if ATot > 0 and sum(ATransparent) > 0
-    "Splits incoming solar radiation into seperate gains for each wall element, 
+    "Splits incoming solar radiation into separate gains for each wall element, 
     weighted by their area"
     annotation (Placement(transformation(extent={{-138,138},{-122,154}})));
   BaseClasses.ExteriorWall extWallRC(
@@ -180,7 +180,7 @@ protected
     "Share of each wall surface area that is non-zero";
   parameter Real splitFactorSolRad[dimension, nOrientations]=
     BaseClasses.splitFacVal(dimension, nOrientations, AArray, AExt, AWin)
-    "Share of each wall surface area that is non-zero, for each orientation seperately";
+    "Share of each wall surface area that is non-zero, for each orientation separately";
   Modelica.Thermal.HeatTransfer.Components.Convection convExtWall if ATotExt > 0
     "Convective heat transfer of exterior walls"
     annotation (Placement(transformation(extent={{-114,-30},{-94,-50}})));

--- a/Annex60/ThermalZones/ReducedOrder/RC/package.mo
+++ b/Annex60/ThermalZones/ReducedOrder/RC/package.mo
@@ -69,7 +69,7 @@ package RC
   </p>
   <p>
   Heat transfer through windows and solar radiation transmission are handled
-  seperately. One major difference in the implementations in this
+  separately. One major difference in the implementations in this
   package compared to the guideline is an additional element for heat transfer
   through windows, which are lumped with exterior walls in the guideline VDI 6007
   Part 1 (VDI, 2012). The heat transfer element for the windows allows to model
@@ -79,11 +79,11 @@ package RC
   exterior walls leads to a virtual capacity for the windows and results in a
   shifted reaction of the room temperature to environmental impacts
   (Lauster, Bruentjen <i>et al.</i>, 2014).
-  However, the user is free to choose whether keeping windows seperately
+  However, the user is free to choose whether keeping windows separately
   (<code>AWin</code>) or merging them (<code>AExt=AExterior+AWindows, AWin=0</code>).
-   The window areas can be defined seperately for solar
+   The window areas can be defined separately for solar
   radiation (vector <code>ATransparent</code>) and heat transfer
-  (vector <code>AWin</code>). For cases where the windows are kept seperately,
+  (vector <code>AWin</code>). For cases where the windows are kept separately,
   <code>ATransparent</code> and <code>AWin</code> are equal. When merging
   windows and exterior walls,  <code>AWin</code> can be set to zero while
   <code>ATransparent</code> still represents the actual window area for solar
@@ -142,7 +142,7 @@ package RC
   one for convective and one for radiative gains. Considering solar radiation
   typically requires several models upstream to calculate angle-dependent
   irradiation or solar absorption and reflection by windows.
-  We decided to keep these models seperate from the thermal
+  We decided to keep these models separate from the thermal
   zone model. Thus, solar radiation is handled as a basic
   <code>RadiantEnergyFluenceRate</code>.
   For internal gains, the user might need
@@ -164,7 +164,7 @@ package RC
   the area of exterior walls and windows with the same orientation as the incoming
   radiation is not taken into account for the distribution as such surfaces cannot
   be hit by the particular radiation. This calculation is performed for each
-  orientation seperately using
+  orientation separately using
   <a href=\"Annex60.ThermalZones.ReducedOrder.RC.BaseClasses.splitFacVal\">
   Annex60.ThermalZones.ReducedOrder.RC.BaseClasses.splitFacVal</a>.
   </p>

--- a/Annex60/ThermalZones/ReducedOrder/Validation/VDI6007/package.mo
+++ b/Annex60/ThermalZones/ReducedOrder/Validation/VDI6007/package.mo
@@ -12,7 +12,7 @@ annotation (Documentation(info="<html>
   exterior wall for the heavyweight construction.</p>
   <p>Comparative results are supplied with the guideline and have been caclulated
   using two different programs for electrical circuit calculations (for day 1,
-  10 and 60 in hourly steps). The validation procedure is orginally thought to
+  10 and 60 in hourly steps). The validation procedure is originally thought to
   verifiy the correct implementation of an analytical calculation algorithm
   defined in the guideline. For that, a range of max 0.1 K or max 1 W deviation
   is allowed. As the implementation cannot reflect all aspects of the algorithm,

--- a/Annex60/Utilities/Math/Functions/average.mo
+++ b/Annex60/Utilities/Math/Functions/average.mo
@@ -8,7 +8,7 @@ algorithm
   y := sum(u)/nin;
 
   annotation (Documentation(info="<html>
-<p>This block outputs the average of the vector. </p>
+<p>This function outputs the average of the vector. </p>
 </html>", revisions="<html>
 <ul>
 <li>November 28, 2013, by Marcus Fuchs:<br/>


### PR DESCRIPTION
This fixes mostly typos in the documentation, but also a few variable names and one css class selector.

https://github.com/vlajos/misspell_fixer