### PR TITLE
remove keyword parameter,

### DIFF
--- a/Annex60/ThermalZones/ReducedOrder/Examples/package.order
+++ b/Annex60/ThermalZones/ReducedOrder/Examples/package.order
@@ -1,4 +1,4 @@
-SimpleRoomFourElements
 SimpleRoomOneElement
-SimpleRoomThreeElements
 SimpleRoomTwoElements
+SimpleRoomThreeElements
+SimpleRoomFourElements

--- a/Annex60/ThermalZones/ReducedOrder/RC/BaseClasses/splitFacVal.mo
+++ b/Annex60/ThermalZones/ReducedOrder/RC/BaseClasses/splitFacVal.mo
@@ -8,8 +8,8 @@ function splitFacVal
   input Modelica.SIunits.Area[nCol] AExt "Vector of exterior wall areas";
   input Modelica.SIunits.Area[nCol] AWin "Vector of window areas";
   output Real[nRow,nCol] splitFacValues "Split factor values for ThermSplitter";
-  parameter Modelica.SIunits.Area ATot=sum(AArray) "Total area";
 protected
+  Modelica.SIunits.Area ATot=sum(AArray) "Total area";
   Integer j=1 "Row counter";
   Integer k=1 "Column counter";
   Integer l=1 "AArray counter";

--- a/Annex60/ThermalZones/ReducedOrder/Validation/VDI6007/package.order
+++ b/Annex60/ThermalZones/ReducedOrder/Validation/VDI6007/package.order
@@ -1,7 +1,4 @@
 TestCase1
-TestCase10
-TestCase11
-TestCase12
 TestCase2
 TestCase3
 TestCase4
@@ -10,4 +7,7 @@ TestCase6
 TestCase7
 TestCase8
 TestCase9
+TestCase10
+TestCase11
+TestCase12
 BaseClasses


### PR DESCRIPTION
make it a protected variable instead
this closes #652 
@mlauster All examples in the Validation.VDI6007 subpackage still simulate.