### PR TITLE
Placement.visible instead of Placement.transformation.visible

### DIFF
--- a/Annex60/Fluid/FMI/Conversion/AirToOutlet.mo
+++ b/Annex60/Fluid/FMI/Conversion/AirToOutlet.mo
@@ -46,9 +46,10 @@ block AirToOutlet
     displayUnit="degC") if
        allowFlowReversal
     "Temperature of the backward flowing medium in the connector outlet"
-    annotation (Placement(transformation(extent={{20,20},{-20,-20}},
-        rotation=90,
+    annotation (Placement(
         visible=allowFloWReserval,
+        transformation(extent={{20,20},{-20,-20}},
+        rotation=90,
         origin={-60,-120}),
         iconTransformation(
         extent={{20,20},{-20,-20}},
@@ -58,9 +59,10 @@ block AirToOutlet
     final unit="kg/kg") if
        Medium.nXi > 0 and allowFlowReversal
     "Water mass fraction per total air mass of the backward flowing medium in the connector outlet"
-    annotation (Placement(transformation(extent={{20,20},{-20,-20}},
-        rotation=90,
+    annotation (Placement(
         visible=allowFloWReserval,
+        transformation(extent={{20,20},{-20,-20}},
+        rotation=90,
         origin={0,-120}),
         iconTransformation(
         extent={{20,20},{-20,-20}},
@@ -70,9 +72,10 @@ block AirToOutlet
     final quantity=Medium.extraPropertiesNames) if
        allowFlowReversal
     "Trace substances of the backward flowing medium in the connector outlet"
-    annotation (Placement(transformation(extent={{20,20},{-20,-20}},
-        rotation=90,
+    annotation (Placement(
         visible=allowFloWReserval,
+        transformation(extent={{20,20},{-20,-20}},
+        rotation=90,
         origin={60,-120}),
         iconTransformation(
         extent={{20,20},{-20,-20}},

--- a/Annex60/Fluid/FMI/Conversion/InletToAir.mo
+++ b/Annex60/Fluid/FMI/Conversion/InletToAir.mo
@@ -22,9 +22,10 @@ block InletToAir
     displayUnit="degC") if
        allowFlowReversal
     "Zone air temperature"
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}},
-        rotation=90,
+    annotation (Placement(
         visible=allowFloWReserval,
+        transformation(extent={{-20,-20},{20,20}},
+        rotation=90,
         origin={-60,-120}),
         iconTransformation(
         extent={{-20,-20},{20,20}},
@@ -34,9 +35,10 @@ block InletToAir
     final unit="kg/kg") if
        Medium.nXi > 0 and allowFlowReversal
     "Zone air water mass fraction per total air mass"
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}},
-        rotation=90,
+    annotation (Placement(
         visible=allowFloWReserval,
+        transformation(extent={{-20,-20},{20,20}},
+        rotation=90,
         origin={0,-120}),
         iconTransformation(
         extent={{-20,-20},{20,20}},
@@ -46,9 +48,10 @@ block InletToAir
     final quantity=Medium.extraPropertiesNames) if
        allowFlowReversal
     "Zone air trace substances"
-    annotation (Placement(transformation(extent={{-20,-20},{20,20}},
-        rotation=90,
+    annotation (Placement(
         visible=allowFloWReserval,
+        transformation(extent={{-20,-20},{20,20}},
+        rotation=90,
         origin={60,-120}),
         iconTransformation(
         extent={{-20,-20},{20,20}},


### PR DESCRIPTION
fixes an error in pedantic mode.


```
Advanced.PedanticModelica=true;
checkModel("Annex60.Fluid.FMI.Conversion");
```

